### PR TITLE
Add Testing Profiles document to the navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
         - ... | flat | MASTG/0x09*.md
       - General Concepts:
         - ... | flat | MASTG/0x04*.md
+        - MASTG/0x03b-Testing-Profiles.md
       - Android Security Testing:
         - ... | flat | MASTG/0x05*.md
       - iOS Security Testing:


### PR DESCRIPTION
This pull request adds a new entry to the navigation structure in `mkdocs.yml`, making the `MASTG/0x03b-Testing-Profiles.md` document directly accessible under the "General Concepts" section.