### PR TITLE
Fix DataTable initialization to only apply to MASTG index pages

### DIFF
--- a/docs/javascripts/datatables.js
+++ b/docs/javascripts/datatables.js
@@ -1,9 +1,32 @@
 
 document$.subscribe(function() {
-    // Add DataTable to all tables, but not the advanced tests table
-    $('table').not("#table_tests table").DataTable({
-        paging: false, // Disable pagination
-        order: [], // Disable auto-sorting
-        dom: '<"top"if>rt<"bottom"lp><"clear">'
-    });
+    // Only apply DataTables on MASTG index pages (whitelist)
+    var currentPath = window.location.pathname;
+
+    var mastgFolders = [
+        'apps',
+        'best-practices',
+        'demos',
+        'knowledge',
+        'techniques',
+        'tests',
+        'tools'
+    ];
+
+    var isIndexPage = false;
+    for (var i = 0; i < mastgFolders.length; i++) {
+        if (currentPath.endsWith('/' + mastgFolders[i] + '/')) {
+            isIndexPage = true;
+            break;
+        }
+    }
+
+    if (isIndexPage) {
+        // Add DataTable to all tables, but not the advanced tests table
+        $('table').not("#table_tests table").DataTable({
+            paging: false, // Disable pagination
+            order: [], // Disable auto-sorting
+            dom: '<"top"if>rt<"bottom"lp><"clear">'
+        });
+    }
 });


### PR DESCRIPTION
Limit DataTable initialization to only apply on MASTG index pages, enhancing performance and usability by avoiding unnecessary application on other pages.