### PR TITLE
ci: declare workflow-level `contents: read` on 2 workflows

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'cpholguera' || github.actor == 'sushi2k' || github.actor == 'TheDauntless'

--- a/.github/workflows/check-website-build.yml
+++ b/.github/workflows/check-website-build.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     branches:
       - "*"
+
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/build-website-reusable.yml


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 2 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

Left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Best declared by a maintainer: `playwright.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.