### PR TITLE
Pin Dockerfile base image to python:3.12-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the latest Python image
-FROM python:3-slim
+FROM python:3.12-slim
 
 # Install dependencies
 RUN apt-get update && \


### PR DESCRIPTION
This PR closes #78 

## Description

The current `Dockerfile` uses the floating **(unpinned)** `python:3-slim` base image.

When it is built in newer environments it will fail since `python:3-slim` automatically tracks the **latest** Python release, and no matching pre-compiled binary wheel exists on PyPI for this specific version combination. The build then crashes immediately because the minimal `slim` base image lacks the necessary compiler toolchain (`gcc`). 

**Pinning** the base image to `python:3.12-slim` fixes this by ensuring compatibility with the existing pre-compiled binaries.