### PR TITLE
Fix bug

### DIFF
--- a/docs/hooks/resolve_references.py
+++ b/docs/hooks/resolve_references.py
@@ -36,7 +36,7 @@ def on_page_markdown(markdown, page, config, **kwargs):
 
         icon = icons_for_text.get(refType, ":octicons-question-24: ")
 
-        return f"_[{icon}{mapping[refType][match]['title']}](/{match.group(1)} \"{refType}\")_"
+        return f"*[{icon}{mapping[refType][match]['title']}](/{match.group(1)} \"{refType}\")*"
 
     def replaceReferenceMASWE(match):
         refType = "MASWE"
@@ -48,7 +48,7 @@ def on_page_markdown(markdown, page, config, **kwargs):
             mapping[refType][match] = target
 
         icon = icons_for_text.get(refType, ":octicons-question-24: ")
-        return f"_[{icon}{mapping[refType][match]['title']}](/{match.group(1)} \"{refType}\")_"
+        return f"*[{icon}{mapping[refType][match]['title']}](/{match.group(1)} \"{refType}\")*"
 
     def replaceReferenceMASVS(match):
         refType = "MASVS"
@@ -60,7 +60,7 @@ def on_page_markdown(markdown, page, config, **kwargs):
             mapping[refType][match] = target
 
         icon = icons_for_text.get(refType, ":octicons-question-24: ")
-        return f"_[{icon}{mapping[refType][match]['title']}](/{match.group(1)} \"{refType}\")_"
+        return f"*[{icon}{mapping[refType][match]['title']}](/{match.group(1)} \"{refType}\")*"
 
 
     updated_markdown = re.sub(r'@(MASTG-(KNOW|TECH|TOOL|TEST|APP|DEMO|BEST)-\d{3,})', replaceReference, markdown)


### PR DESCRIPTION
Bug on TOOL pages where the first paragraph also contains a tool reference:

https://mas.owasp.org/MASTG/tools/generic/MASTG-TOOL-0134/

<img width="393" height="304" alt="image" src="https://github.com/user-attachments/assets/30c08838-d507-4615-ae32-04917327e680" />

This change fixes it:
<img width="413" height="265" alt="image" src="https://github.com/user-attachments/assets/27e29d37-9b98-4427-afd5-0ebec28591e1" />
