### PR TITLE
ci: declare explicit contents: write for gh-pages deploy workflows

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -10,9 +10,14 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'cpholguera' || github.actor == 'sushi2k' || github.actor == 'TheDauntless'
+    permissions:
+      contents: write
     uses: ./.github/workflows/build-website-reusable.yml
     with:
       deploy: true

--- a/.github/workflows/monitor-repos-and-deploy.yml
+++ b/.github/workflows/monitor-repos-and-deploy.yml
@@ -5,6 +5,9 @@ on:
     - cron: "*/30 * * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -59,6 +62,8 @@ jobs:
   deploy:
     needs: check
     if: needs.check.outputs.changed == 'true'
+    permissions:
+      contents: write
     uses: ./.github/workflows/build-website-reusable.yml
     with:
       deploy: true
@@ -69,6 +74,8 @@ jobs:
     needs: [check, deploy]
     if: needs.check.outputs.changed == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout gh-pages
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR will be merged after switching the repo's default GitHub Actions workflow permissions from "read and write" to "read repository contents" (see review of #76).

<img width="941" height="235" alt="Screenshot 2026-07-04 at 20 39 18" src="https://github.com/user-attachments/assets/de3890f6-fee7-4bf9-b4e7-fe1bda607366" />


- `build-website.yml` (deploy job) and `monitor-repos-and-deploy.yml` (`deploy` and `record` jobs) push to the `gh-pages` branch — via `mkdocs gh-deploy` in `build-website-reusable.yml` and a direct `git push origin gh-pages` in the `record` job — and currently rely on the implicit repo-wide write default for that.
- Adds `permissions: contents: read` as the workflow-level baseline in both files, with `contents: write` declared explicitly at the job level only for the jobs that actually push. The `check` job in `monitor-repos-and-deploy.yml` only reads, so it's left at the read-only default.


**NOTE:** After the setting change, confirm the next `monitor-repos-and-deploy.yml` scheduled run (or manual `workflow_dispatch` of `build-website.yml`) still successfully pushes to `gh-pages`