### PR TITLE
Python requirements version bump

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 mkdocs==1.6.1
 mkdocs-awesome-pages-plugin==2.9.2
 mkdocs-include-dir-to-nav==1.2.0
-mkdocs-material==9.6.11
+mkdocs-material==9.6.23
 mkdocs-redirects==1.2.2
 pandas==2.3.0
 pyyaml==6.0.2
 tabulate==0.9.0
-requests==2.32.4
-lxml==5.4.0
+requests==2.33.0
+lxml==6.1.0
 bs4==0.0.2
 openpyxl==3.1.5
-Pillow==11.3.0
+Pillow==12.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 mkdocs==1.6.1
 mkdocs-awesome-pages-plugin==2.9.2
 mkdocs-include-dir-to-nav==1.2.0
-mkdocs-material==9.6.23
+mkdocs-material==9.7.7
 mkdocs-redirects==1.2.2
 pandas==2.3.0
 pyyaml==6.0.2
+pymdown-extensions==11.0.1
 tabulate==0.9.0
 requests==2.33.0
 lxml==6.1.0


### PR DESCRIPTION
Fixes #99 

Updated all Python dependencies in the `requirement.txt` to secure versions and tested if the page still builds.

`pymdown-extensions==11.0.1` was pinned explicitly.